### PR TITLE
Add initial ECS web service Terraform module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,70 @@
+# terraform-aws-ecs-web-service
+
+A Terraform module to create an Amazon Web Services (AWS) EC2 Container Service (ECS) service associated with an Application Load Balancer (ALB).
+
+## Usage
+
+```hcl
+resource "aws_ecs_task_definition" "app" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  family                = "ProductionApp"
+  container_definitions = "..."
+}
+
+module "app_web_service" {
+  source = "github.com/azavea/terraform-aws-ecs-web-service?ref=0.1.0"
+
+  name                = "App"
+  vpc_id              = "vpc-..."
+  public_subnet_ids   = ["subnet-...", "subnet-..."]
+  access_log_bucket   = "logs-bucket"
+  access_log_prefix   = "ALB"
+  health_check_path   = "/health-check/"
+  port                = "8080"
+  ssl_certificate_arn = "arn..."
+
+  cluster_name                   = "default"
+  task_definition_id             = "${aws_ecs_task_definition.app.family}:${aws_ecs_task_definition.app.revision}"
+  desired_count                  = "1"
+  deployment_min_healthy_percent = "100"
+  deployment_max_percent         = "200"
+
+  container_name = "django"
+  container_port = "8080"
+
+  project     = "${var.project}"
+  environment = "${var.environment}"
+}
+```
+
+## Variables
+
+- `ecs_service_role_policy_arn` - Policy ARN for ECS service role (default: `AmazonEC2ContainerServiceRole`)
+- `vpc_id` - ID of VPC housing the service
+- `name` - Name of the service
+- `public_subnet_ids` - A list of public subnet IDs used to place load balancers
+- `access_log_bucket` - Bucket name used to collect load balancer access logs
+- `access_log_prefix` - Prefix within bucket to nest load balancer access logs
+- `health_check_path` - Path to use for service health check (default: `/`)
+- `port` - Port used for the load balancer target group
+- `ssl_certificate_arn` - ARN of the certificate to associate with the HTTPS listener
+- `cluster_name` - ECS cluster name to associate with the service
+- `task_definition_id` - Concatenation of ECS task definition family and revision separated by a colon
+- `desired_count` - Desired number of service instances (default: `1`)
+- `deployment_min_healthy_percent` - Minimum healthy service instances as a percentage (default: `100`)
+- `deployment_max_percent` - Maximum service instances as a percentage (default: `200`)
+- `container_name` - Name of container in task definition to associate with load balancer
+- `container_port` - Port exposed by container in task definition to associate with load balancer
+- `project` - Name of project for this service (default: `Unknown`)
+- `environment` - Name of environment for this service (default: `Unknown`)
+
+## Outputs
+
+- `id` - The service ARN
+- `name` - The service name
+- `lb_zone_id` - Service load balancer hosted zone ID
+- `lb_dns_name` - Service load balancer DNS name
+- `lb_security_group_id` - Security group ID of load balancer security group

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,117 @@
+#
+# IAM resources
+#
+data "aws_iam_policy_document" "ecs_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "ecs_service_role" {
+  name               = "ecs${var.environment}ServiceRole"
+  assume_role_policy = "${data.aws_iam_policy_document.ecs_assume_role.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_service_role" {
+  role       = "${aws_iam_role.ecs_service_role.name}"
+  policy_arn = "${var.ecs_service_role_policy_arn}"
+}
+
+#
+# Security group resources
+#
+resource "aws_security_group" "main" {
+  vpc_id = "${var.vpc_id}"
+
+  tags {
+    Name        = "sg${var.name}LoadBalancer"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+#
+# ALB resources
+#
+resource "aws_alb" "main" {
+  security_groups = ["${aws_security_group.main.id}"]
+  subnets         = ["${var.public_subnet_ids}"]
+  name            = "alb${var.environment}${var.name}"
+
+  access_logs {
+    bucket = "${var.access_log_bucket}"
+    prefix = "${var.access_log_prefix}"
+  }
+
+  tags {
+    Name        = "alb${var.environment}${var.name}"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_alb_target_group" "main" {
+  name = "tg${var.environment}${var.name}"
+
+  health_check {
+    healthy_threshold   = "3"
+    interval            = "30"
+    protocol            = "HTTP"
+    timeout             = "3"
+    path                = "${var.health_check_path}"
+    unhealthy_threshold = "2"
+  }
+
+  port     = "${var.port}"
+  protocol = "HTTP"
+  vpc_id   = "${var.vpc_id}"
+
+  tags {
+    Name        = "tg${var.environment}${var.name}"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_alb_listener" "https" {
+  load_balancer_arn = "${aws_alb.main.id}"
+  port              = "443"
+  protocol          = "HTTPS"
+
+  certificate_arn = "${var.ssl_certificate_arn}"
+
+  default_action {
+    target_group_arn = "${aws_alb_target_group.main.id}"
+    type             = "forward"
+  }
+}
+
+#
+# ECS resources
+#
+resource "aws_ecs_service" "main" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  name                               = "${var.environment}${var.name}"
+  cluster                            = "${var.cluster_name}"
+  task_definition                    = "${var.task_definition_id}"
+  desired_count                      = "${var.desired_count}"
+  deployment_minimum_healthy_percent = "${var.deployment_min_healthy_percent}"
+  deployment_maximum_percent         = "${var.deployment_max_percent}"
+  iam_role                           = "${aws_iam_role.ecs_service_role.name}"
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.main.id}"
+    container_name   = "${var.container_name}"
+    container_port   = "${var.container_port}"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,19 @@
+output "id" {
+  value = "${aws_ecs_service.main.id}"
+}
+
+output "name" {
+  value = "${aws_ecs_service.main.name}"
+}
+
+output "lb_zone_id" {
+  value = "${aws_alb.main.zone_id}"
+}
+
+output "lb_dns_name" {
+  value = "${aws_alb.main.dns_name}"
+}
+
+output "lb_security_group_id" {
+  value = "${aws_security_group.main.id}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,11 @@ output "lb_dns_name" {
 output "lb_security_group_id" {
   value = "${aws_security_group.main.id}"
 }
+
+output "appautoscaling_policy_scale_up_arn" {
+  value = "${aws_appautoscaling_policy.up.arn}"
+}
+
+output "appautoscaling_policy_scale_down_arn" {
+  value = "${aws_appautoscaling_policy.down.arn}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,51 @@
+variable "project" {
+  default = "Unknown"
+}
+
+variable "environment" {
+  default = "Unknown"
+}
+
+variable "ecs_service_role_policy_arn" {
+  default = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
+}
+
+variable "vpc_id" {}
+
+variable "name" {}
+
+variable "public_subnet_ids" {
+  type = "list"
+}
+
+variable "access_log_bucket" {}
+
+variable "access_log_prefix" {}
+
+variable "health_check_path" {
+  default = "/"
+}
+
+variable "port" {}
+
+variable "ssl_certificate_arn" {}
+
+variable "cluster_name" {}
+
+variable "task_definition_id" {}
+
+variable "desired_count" {
+  default = "1"
+}
+
+variable "deployment_min_healthy_percent" {
+  default = "100"
+}
+
+variable "deployment_max_percent" {
+  default = "200"
+}
+
+variable "container_name" {}
+
+variable "container_port" {}

--- a/variables.tf
+++ b/variables.tf
@@ -6,10 +6,6 @@ variable "environment" {
   default = "Unknown"
 }
 
-variable "ecs_service_role_policy_arn" {
-  default = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
-}
-
 variable "vpc_id" {}
 
 variable "name" {}
@@ -49,3 +45,19 @@ variable "deployment_max_percent" {
 variable "container_name" {}
 
 variable "container_port" {}
+
+variable "min_count" {
+  default = "1"
+}
+
+variable "max_count" {
+  default = "1"
+}
+
+variable "scale_up_cooldown_seconds" {
+  default = "300"
+}
+
+variable "scale_down_cooldown_seconds" {
+  default = "300"
+}


### PR DESCRIPTION
Use Terraform configuration to define all of the AWS resources needed to support an Amazon ECS service. This includes:

- IAM role assumed by the ECS service
- Application Load Balancer (ALB), target group, and listener
- Security group associated with load ALB
- ECS service
- Application AutoScaling support for the ECS service

Fixes https://github.com/azavea/terraform-aws-ecs-web-service/issues/2

---

**Testing**

Use https://github.com/azavea/collab-for-children/pull/105 to test.