### PR TITLE
Remove IAM Permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ resource "aws_cloudwatch_metric_alarm" "app_service_low_cpu" {
 - `ssl_certificate_arn` - ARN of the certificate to associate with the HTTPS listener
 - `cluster_name` - ECS cluster name to associate with the service
 - `task_definition_id` - Concatenation of ECS task definition family and revision separated by a colon
+- `ecs_service_role_name` - Name of IAM role for ECS tasks
+- `ecs_autoscale_role_arn` - ARN of IAM role for ECS Application Autoscaling
 - `desired_count` - Desired number of service instances (default: `1`)
 - `min_count` - Minimum number of service instances (default: `1`)
 - `max_count` - Maximum number of service instances (default: `1`)

--- a/variables.tf
+++ b/variables.tf
@@ -61,3 +61,6 @@ variable "scale_up_cooldown_seconds" {
 variable "scale_down_cooldown_seconds" {
   default = "300"
 }
+
+variable "ecs_service_role_name" {}
+variable "ecs_autoscale_role_arn" {}


### PR DESCRIPTION
# Overview 
Move IAM permission creation to [azavea/terraform-aws-ecs-cluster](https://github.comazavea/terraform-aws-ecs-cluster). The purpose of this removal is to prevent every service launched into an ECS cluster from creating its own IAM permissions. See azavea/terraform-aws-ecs-cluster#5 for more information

# Testing
See geotrellis/geotrellis-transit# .

Connects azavea/terraform-aws-ecs-cluster#5