### PR TITLE
Add step_scaling_policy_configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -112,13 +112,15 @@ resource "aws_appautoscaling_policy" "up" {
   resource_id        = "service/${var.cluster_name}/${aws_ecs_service.main.name}"
   scalable_dimension = "ecs:service:DesiredCount"
 
-  adjustment_type         = "ChangeInCapacity"
-  cooldown                = "${var.scale_up_cooldown_seconds}"
-  metric_aggregation_type = "Average"
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = "${var.scale_up_cooldown_seconds}"
+    metric_aggregation_type = "Average"
 
-  step_adjustment {
-    metric_interval_lower_bound = 0
-    scaling_adjustment          = 1
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
   }
 
   depends_on = [
@@ -132,13 +134,15 @@ resource "aws_appautoscaling_policy" "down" {
   resource_id        = "service/${var.cluster_name}/${aws_ecs_service.main.name}"
   scalable_dimension = "ecs:service:DesiredCount"
 
-  adjustment_type         = "ChangeInCapacity"
-  cooldown                = "${var.scale_down_cooldown_seconds}"
-  metric_aggregation_type = "Average"
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = "${var.scale_down_cooldown_seconds}"
+    metric_aggregation_type = "Average"
 
-  step_adjustment {
-    metric_interval_upper_bound = 0
-    scaling_adjustment          = -1
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = -1
+    }
   }
 
   depends_on = [


### PR DESCRIPTION
Fixes deprecation warnings in terraform `0.10.x`.

# Testing
See raster-foundry/prediction-api/pull/14