### PR TITLE
Add matcher to alb_target_group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ resource "aws_alb_target_group" "main" {
     healthy_threshold   = "3"
     interval            = "30"
     protocol            = "HTTP"
+    matcher             = "200"
     timeout             = "3"
     path                = "${var.health_check_path}"
     unhealthy_threshold = "2"


### PR DESCRIPTION
## Overview

Add `matcher` to `alb_target_group` resource.

Fixes #9 

## Testing

I tested this change when bringing up the ECS cluster in https://github.com/azavea/terraform-aws-ecs-cluster/pull/34.
