### PR TITLE
Remove role_arn from aws_appautoscaling_target

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ resource "aws_cloudwatch_metric_alarm" "app_service_low_cpu" {
 - `cluster_name` - ECS cluster name to associate with the service
 - `task_definition_id` - Concatenation of ECS task definition family and revision separated by a colon
 - `ecs_service_role_name` - Name of IAM role for ECS tasks
-- `ecs_autoscale_role_arn` - ARN of IAM role for ECS Application Autoscaling
 - `desired_count` - Desired number of service instances (default: `1`)
 - `min_count` - Minimum number of service instances (default: `1`)
 - `max_count` - Maximum number of service instances (default: `1`)

--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,6 @@ resource "aws_appautoscaling_target" "main" {
   service_namespace  = "ecs"
   resource_id        = "service/${var.cluster_name}/${aws_ecs_service.main.name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  role_arn           = "${var.ecs_autoscale_role_arn}"
   min_capacity       = "${var.min_count}"
   max_capacity       = "${var.max_count}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -63,4 +63,3 @@ variable "scale_down_cooldown_seconds" {
 }
 
 variable "ecs_service_role_name" {}
-variable "ecs_autoscale_role_arn" {}


### PR DESCRIPTION
## Overview

There isn't a case where we'd want to specify `role_arn`.

>Application Auto Scaling automatically creates the SLR in your account when you call RegisterScalableTarget or PutScalingPolicy if you have the IAM CreateServiceLinkedRole permission.

The only time `role_arn` is applicable, `RegisterScalableTarget` or `PutScalingPolicy` is invoked, and `role_arn` would be replaced by AWS with the arn to the service linked role.

See:

 * https://forums.aws.amazon.com/thread.jspa?threadID=270113
 * azavea/terraform-aws-ecs-cluster#24

Fixes #10 

## Testing

I ran `plan` and `apply` on a test ECS cluster I have running on the Azavea R&D account.